### PR TITLE
Batch load cell data to reduce cell-by-cell calls to Google APIs

### DIFF
--- a/src/GoogleSheet.ts
+++ b/src/GoogleSheet.ts
@@ -8,14 +8,14 @@ export class GoogleSheet {
     return this.api.title
   }
 
-  public async getSingleCell(sheetName: string, ref: string): Promise<string> {
+  public async getCells(sheetName: string, ...refs: string[]): Promise<string[]> {
     let sheet = this.api.sheetsByIndex[0]
     if (sheetName !== '') {
       sheet = this.api.sheetsByTitle[sheetName]
     }
 
-    await sheet.loadCells(`${ref}:${ref}`)
-    return await sheet.getCellByA1(ref).value
+    await sheet.loadCells(refs.map(ref => `${ref}:${ref}`))
+    return refs.map(ref => sheet.getCellByA1(ref).value)
   }
 
   public async authenticate(email: string, privateKey: string): Promise<void> {

--- a/src/SheetTxt.ts
+++ b/src/SheetTxt.ts
@@ -6,7 +6,7 @@ import { writeFileSync } from 'fs'
 const REFRESH_INTERVAL = 10
 
 export class SheetTxt {
-  private static sheets = {}
+  private static sheets: Record<string, GoogleSheet> = {}
 
   public static async run (): Promise<void> {
     await this.init()
@@ -30,10 +30,15 @@ export class SheetTxt {
   private static async refreshAll (): Promise<void> {
     await Promise.all(params.map(async sheetParams => {
       const selectedSheet = sheetParams.sheetName
-      await Promise.all(sheetParams.cells.map(async cellParams => {
-        const cellContents = await this.sheets[sheetParams.spreadsheetId].getSingleCell(selectedSheet, cellParams.cell)
-        await writeFileSync(cellParams.path, cellContents)
-      }))
+
+      const cellsRefs = sheetParams.cells.map(({ cell }) => cell)
+      const cellsData = await this.sheets[sheetParams.spreadsheetId].getCells(selectedSheet, ...cellsRefs)
+
+      sheetParams.cells.forEach((cellParams, cellIndex) => {
+        const cellContents = cellsData[cellIndex]
+
+        writeFileSync(cellParams.path, cellContents)
+      })
     }))
   }
 }


### PR DESCRIPTION
This introduces batch loading for cells, to reduce the number of cell-by-cell calls to the Google APIs.

This also introduces strong typing for `SheetTxt.sheets` and removes an errant `await` on a `writeFileSync` call.