### PR TITLE
Use setTimeout instead of setInterval

### DIFF
--- a/src/SheetTxt.ts
+++ b/src/SheetTxt.ts
@@ -10,7 +10,13 @@ export class SheetTxt {
 
   public static async run (): Promise<void> {
     await this.init()
-    setInterval(this.refreshAll.bind(this), REFRESH_INTERVAL * 1000)
+
+    const tick = async () => {
+      await this.refreshAll.call(this)
+      setTimeout(tick, REFRESH_INTERVAL * 1000)
+    }
+
+    tick()
   }
 
   private static async init (): Promise<void> {


### PR DESCRIPTION
This switches from `setInterval` for repeated refreshes, to  using `setTimeout`. This prevents an issue where a long running refresh could still be running before another starts - causing a cascade of refreshes.

This also allows the refresh function to be called immediately, rather than after the first refresh interval has expired.